### PR TITLE
Fixed --userinfo-endpoint not being parsed from command line options

### DIFF
--- a/oidc-client.sh
+++ b/oidc-client.sh
@@ -293,6 +293,12 @@ while (( "$#" )); do
         shift 2
       fi
       ;;
+    --userinfo-endpoint)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        USERINFO_ENDPOINT=$2
+        shift 2
+      fi
+      ;;
     --token-endpoint)
       if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
         TOKEN_ENDPOINT=$2
@@ -635,4 +641,3 @@ case "$OPERATION" in
     ;;
   
 esac
-

--- a/oidc-client.sh
+++ b/oidc-client.sh
@@ -224,7 +224,7 @@ function show_help {
 echo "PLEASE-OPEN.IT BASH CLIENT"
 echo "SYNOPSIS"
 echo ""
-echo "oidc-client.sh --operation OP --openid-endpoint [--authorization-endpoint --token-introspection-endpoint --token-endpoint --end-session-endpoint --device-authorization-endpoint] --client-id --client-secret --username --password --scope --access-token --refresh-token --issuer --redirect-uri --authorization-code --device-code --acr --field "
+echo "oidc-client.sh --operation OP --openid-endpoint [--authorization-endpoint --token-introspection-endpoint --token-endpoint --end-session-endpoint --device-authorization-endpoint --userinfo-endpoint] --client-id --client-secret --username --password --scope --access-token --refresh-token --issuer --redirect-uri --authorization-code --device-code --acr --field "
 
 
 


### PR DESCRIPTION
I ran into the issue that the `--userinfo-endpoint` parameter does not appear to be parsed correctly from CLI options while debugging an OpenID issue for a customer. The only way to specify the endpoint is to use `--openid-endpoint` instead. Since I had to fix it anyway I might as well contribute it here.

Not sure if this project is still active, the script was rather helpful though.